### PR TITLE
Replace posterior with prior wherever post_norm is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. The format 
 
 - Support for running notebooks via google colab (issue #6)
 
+### Fixed
+
+- Handle cases where the posterior is un-normalizable for some (parameter,design) combinations (issue #5)
+
 ## [0.4.0] - 2024-09-24
 
 ### Added

--- a/src/bed/design.py
+++ b/src/bed/design.py
@@ -82,13 +82,14 @@ class ExperimentDesigner:
                 assert np.allclose(marginal, self.marginal), "marginal check failed"
 
             # Tabulate the posterior P(theta|y,xi) by normalizing P(y|theta,xi) P(theta) over parameters.
-            post_norm = self.parameters.sum(self._buffer, keepdims=True)
             # Use the prior for any (design, feature) points where the likelihood x prior is zero
-            # so the corresponding information gain
-            iszero = post_norm == 0
-            self._buffer[~iszero] /= post_norm[~iszero]
-            self._buffer[iszero] = self.prior[iszero]
+            # so the corresponding information gain is zero.
+            post_norm = self.parameters.sum(self._buffer, keepdims=True)
+            self._buffer = np.divide(
+                self._buffer, post_norm, out=self._buffer, where=post_norm > 0
+            )
             if debug:
+                # This will fail if the likelihood*prior is zero for any (design, feature) point.
                 posterior = self.parameters.normalize(self.likelihood * self.prior)
                 assert np.allclose(posterior, self._buffer), "posterior check failed"
 
@@ -97,8 +98,11 @@ class ExperimentDesigner:
             np.log2(self._buffer, out=self._buffer, where=self._buffer > 0)
             self._buffer *= self.likelihood
             self._buffer *= self.prior
-            self._buffer /= post_norm
+            self._buffer = np.divide(
+                self._buffer, post_norm, out=self._buffer, where=post_norm > 0
+            )
             self.IG = self.H0 + self.parameters.sum(self._buffer)
+            self.IG[post_norm.reshape(self.IG.shape) == 0] = 0
             if debug:
                 log2posterior = np.log2(
                     posterior, out=np.zeros_like(posterior), where=posterior > 0
@@ -109,7 +113,12 @@ class ExperimentDesigner:
             # Leave the posterior in the buffer.
             self._buffer[:] = self.likelihood
             self._buffer *= self.prior
-            self._buffer /= post_norm
+            self._buffer = np.divide(
+                self._buffer, post_norm, out=self._buffer, where=post_norm > 0
+            )
+            self._buffer = np.add(
+                self._buffer, self.prior, out=self._buffer, where=post_norm == 0
+            )
 
         with GridStack(self.features, self.designs):
             # Tabulate the expected information gain in bits as avg of IG(y,xi) with weights P(y|xi).

--- a/src/bed/design.py
+++ b/src/bed/design.py
@@ -83,7 +83,11 @@ class ExperimentDesigner:
 
             # Tabulate the posterior P(theta|y,xi) by normalizing P(y|theta,xi) P(theta) over parameters.
             post_norm = self.parameters.sum(self._buffer, keepdims=True)
-            self._buffer /= post_norm
+            # Use the prior for any (design, feature) points where the likelihood x prior is zero
+            # so the corresponding information gain
+            iszero = post_norm == 0
+            self._buffer[~iszero] /= post_norm[~iszero]
+            self._buffer[iszero] = self.prior[iszero]
             if debug:
                 posterior = self.parameters.normalize(self.likelihood * self.prior)
                 assert np.allclose(posterior, self._buffer), "posterior check failed"


### PR DESCRIPTION
If the likelihood x prior sums to zero for any (design,feature) combination, the resulting posterior is un-normalizable and the corresponding information gain is undefined.

Solve this by replacing the posterior with the prior whenever the sum (called `post_norm` in the code) is zero.